### PR TITLE
Remove emsdk dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -22,7 +22,6 @@ requirements:
     - python >=3.6
     - typer
     - requests
-    - emsdk
     - pyyaml
     - pydantic
 


### PR DESCRIPTION
@DerThorsten now that empack downloads emsdk if needed, we should not require this dependency (just like when installing empack with pip).